### PR TITLE
Get Protocol / Hostname from Browser Window

### DIFF
--- a/ckui.js
+++ b/ckui.js
@@ -382,7 +382,7 @@ function loadBlockExplorer() {
 
 $(document).ready(function() {
     $.jsonRPC.setup({
-      endPoint: endPoint: window.location.protocol+'//'+window.location.hostname+':8383',
+      endPoint: window.location.protocol+'//'+window.location.hostname+':8383',
       namespace: ''
     });
 

--- a/ckui.js
+++ b/ckui.js
@@ -382,7 +382,7 @@ function loadBlockExplorer() {
 
 $(document).ready(function() {
     $.jsonRPC.setup({
-      endPoint: 'http://localhost:8383/',
+      endPoint: endPoint: window.location.protocol+'//'+window.location.hostname+':8383',,
       namespace: ''
     });
 

--- a/ckui.js
+++ b/ckui.js
@@ -382,7 +382,7 @@ function loadBlockExplorer() {
 
 $(document).ready(function() {
     $.jsonRPC.setup({
-      endPoint: endPoint: window.location.protocol+'//'+window.location.hostname+':8383',,
+      endPoint: endPoint: window.location.protocol+'//'+window.location.hostname+':8383',
       namespace: ''
     });
 


### PR DESCRIPTION
Rather than hardcoding localhost, take the protocol and hostname from the DOM.